### PR TITLE
feat: run auth on edge runtime

### DIFF
--- a/src/lib/auth-edge.ts
+++ b/src/lib/auth-edge.ts
@@ -1,3 +1,4 @@
+export const runtime = "edge";
 // src/lib/auth-edge.ts
 import NextAuth, { type DefaultSession } from "next-auth";
 import EmailProvider from "next-auth/providers/email";


### PR DESCRIPTION
## Summary
- set `runtime` export to `"edge"` in auth edge module

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Missing API key)*
- `npx vercel deploy --prebuilt` *(fails: No existing credentials found)*

------
https://chatgpt.com/codex/tasks/task_e_689e653776a0832a9280018e38450b38