### PR TITLE
Log authorized middleware usage

### DIFF
--- a/src/lib/auth-edge.ts
+++ b/src/lib/auth-edge.ts
@@ -83,6 +83,10 @@ export const authConfig = {
      */
     authorized({ auth, request }: { auth: import("next-auth").Session | null; request: Request }) {
       const { pathname } = new URL(request.url);
+      console.log("middleware authorized", {
+        pathname,
+        user: auth?.user?.email,
+      });
       const isPublic =
         pathname.startsWith("/signin") ||
         pathname.startsWith("/api/auth") ||


### PR DESCRIPTION
## Summary
- log pathname and user email during auth middleware authorization

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Missing Resend API key)*
- `npx vercel --prod --confirm` *(fails: interactive prompt required)*

------
https://chatgpt.com/codex/tasks/task_e_689e650d776c832ab7573167cf2ab7f1