### PR TITLE
Set admin flag in JWT based on ADMIN_EMAILS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+DATABASE_URL="postgres://USER:PASSWORD@HOST:PORT/DBNAME"
+EMAIL_FROM="no-reply@example.com"
+RESEND_API_KEY="your-resend-api-key"
+# Comma-separated list of admin emails
+ADMIN_EMAILS="admin1@example.com,admin2@example.com"

--- a/README.md
+++ b/README.md
@@ -3,10 +3,16 @@
 ## Local Dev (optional)
 ```bash
 npm i
-cp .env.example .env # set DATABASE_URL
+cp .env.example .env # set DATABASE_URL, EMAIL_FROM, RESEND_API_KEY, ADMIN_EMAILS
 npx prisma migrate dev
 npm run dev
 ```
+
+## Environment
+
+- `DATABASE_URL` – connection string for Postgres
+- `EMAIL_FROM` and `RESEND_API_KEY` – used for magic link emails
+- `ADMIN_EMAILS` – comma‑separated emails with admin access. During sign‑in, if the user's email (case‑insensitive) matches one of these, the JWT will include `isAdmin: true`.
 
 ## Deploy (Vercel + Neon, recommended)
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -65,17 +65,34 @@ export const authConfig = {
       return addr.endsWith("@meta.com");
     },
 
-    // Put id + isAdmin in the session
-    async session(params: {
-      session: import("next-auth").Session;
-      user: { id: string; email?: string | null; isAdmin?: boolean };
-      token?: unknown;
+    // Put custom claims in the JWT
+    async jwt({ token, user }: {
+      token: { isAdmin?: boolean } & import("next-auth/jwt").JWT;
+      user?: { email?: string | null };
     }) {
-      const { session, user } = params;
+      if (user?.email) {
+        const emailLower = user.email.toLowerCase();
+        token.isAdmin = ADMIN_EMAILS.includes(emailLower);
+      }
+      return token;
+    },
+
+    // Put id + isAdmin in the session
+    async session({
+      session,
+      token,
+      user,
+    }: {
+      session: import("next-auth").Session;
+      token: { isAdmin?: boolean; sub?: string };
+      user: { id: string; email?: string | null; isAdmin?: boolean };
+    }) {
       if (session.user) {
         session.user.id = user.id;
-        const emailLower = (user.email ?? "").toLowerCase();
-        session.user.isAdmin = !!user.isAdmin || ADMIN_EMAILS.includes(emailLower);
+        session.user.isAdmin =
+          token.isAdmin ??
+          (!!user.isAdmin ||
+            ADMIN_EMAILS.includes((user.email ?? "").toLowerCase()));
       }
       return session;
     },


### PR DESCRIPTION
## Summary
- add jwt callback that flags admins and expose claim in sessions
- document ADMIN_EMAILS and add example env file

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Missing API key. Pass it to the constructor `new Resend("re_123")`)*

------
https://chatgpt.com/codex/tasks/task_e_689f3ab14008832a968c4242e28abe69