### PR TITLE
docs: switch auth instructions to Google Identity Services

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 DATABASE_URL="postgres://USER:PASSWORD@HOST:PORT/DBNAME"
-EMAIL_FROM="no-reply@example.com"
-RESEND_API_KEY="your-resend-api-key"
+# Secret used to sign authentication tokens
+AUTH_SECRET="your-auth-secret"
+# Client ID from Google Identity Services
+NEXT_PUBLIC_GOOGLE_CLIENT_ID="your-google-client-id"
 # Comma-separated list of admin emails
 ADMIN_EMAILS="admin1@example.com,admin2@example.com"

--- a/README.md
+++ b/README.md
@@ -3,15 +3,25 @@
 ## Local Dev (optional)
 ```bash
 npm i
-cp .env.example .env # set DATABASE_URL, EMAIL_FROM, RESEND_API_KEY, ADMIN_EMAILS
+cp .env.example .env # set DATABASE_URL, AUTH_SECRET, NEXT_PUBLIC_GOOGLE_CLIENT_ID, ADMIN_EMAILS
 npx prisma migrate dev
 npm run dev
 ```
 
+## Authentication
+
+This project uses [Google Identity Services](https://developers.google.com/identity) for authentication.
+
+1. Create a Google Cloud project and enable Google Identity Services.
+2. Configure an OAuth 2.0 Client ID for a web application.
+3. Add `http://localhost:3000` to the authorized JavaScript origins for local development.
+4. Set the client ID as `NEXT_PUBLIC_GOOGLE_CLIENT_ID` (or `GOOGLE_CLIENT_ID`) in your environment.
+
 ## Environment
 
 - `DATABASE_URL` – connection string for Postgres
-- `EMAIL_FROM` and `RESEND_API_KEY` – used for magic link emails
+- `AUTH_SECRET` – secret used to sign authentication tokens
+- `GOOGLE_CLIENT_ID` or `NEXT_PUBLIC_GOOGLE_CLIENT_ID` – client ID from Google Identity Services
 - `ADMIN_EMAILS` – comma‑separated emails with admin access. During sign‑in, if the user's email (case‑insensitive) matches one of these, the JWT will include `isAdmin: true`.
 
 ## Deploy (Vercel + Neon, recommended)


### PR DESCRIPTION
## Summary
- document Google Identity Services setup for auth
- note AUTH_SECRET and Google client ID env variables

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f4413f5e4832aabb769a24f13cdf6