### PR TITLE
Add verifySession helper and use session email

### DIFF
--- a/src/app/api/auth/session/route.ts
+++ b/src/app/api/auth/session/route.ts
@@ -1,8 +1,8 @@
 // src/app/api/auth/session/route.ts
 import { NextRequest, NextResponse } from "next/server";
-import { getSessionFromRequest } from "@/lib/session";
+import { verifySession } from "@/lib/session";
 
-export async function GET(req: NextRequest) {
-  const s = await getSessionFromRequest(req);
+export async function GET(_req: NextRequest) {
+  const s = await verifySession();
   return NextResponse.json({ user: s });
 }

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -15,7 +15,7 @@ export async function POST(req: NextRequest) {
     }
 
     const session = await verifySession();
-    const author = session?.user?.email || b.author || 'anon';
+    const author = session?.email || b.author || 'anon';
 
     const fb = await prisma.feedback.create({
       data: {

--- a/src/app/api/vendors/route.ts
+++ b/src/app/api/vendors/route.ts
@@ -5,7 +5,7 @@ export const runtime = "nodejs";
 
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
-import { getSessionFromRequest } from "@/lib/session";
+import { verifySession } from "@/lib/session";
 
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
@@ -96,7 +96,7 @@ export async function GET(req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
-  const session = await getSessionFromRequest(req);
+  const session = await verifySession();
   if (!session?.isAdmin) {
     return NextResponse.json({ error: "admin only" }, { status: 403 });
   }

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,6 +1,7 @@
 // src/lib/session.ts
 import { SignJWT, jwtVerify } from "jose";
 import type { NextRequest } from "next/server";
+import { cookies } from "next/headers";
 
 const COOKIE_NAME = "vh_session";
 const ISSUER = "vendorhub";
@@ -38,6 +39,11 @@ export async function verifyToken(token?: string): Promise<Session | null> {
   } catch {
     return null;
   }
+}
+
+export async function verifySession(): Promise<Session | null> {
+  const token = cookies().get(COOKIE_NAME)?.value;
+  return verifyToken(token);
 }
 
 export async function getSessionFromRequest(


### PR DESCRIPTION
## Summary
- add `verifySession` helper using `cookies()` to verify JWT from session cookie
- update API routes to use `verifySession`
- reference `session.email` instead of `session.user.email` in feedback API

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f50d7fdd8832a82c7802c15efac7a