### PR TITLE
Use API logout endpoint on home page

### DIFF
--- a/src/app/components/SignOutButton.tsx
+++ b/src/app/components/SignOutButton.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import React from 'react';
+
+export default function SignOutButton() {
+  async function handleLogout() {
+    await fetch('/api/auth/logout', { method: 'POST' });
+    window.location.href = '/signin';
+  }
+
+  return (
+    <button
+      onClick={handleLogout}
+      className="rounded-xl border border-gray-300 px-3 py-2 text-sm hover:bg-gray-100"
+    >
+      Sign out
+    </button>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import React from 'react';
 import { verifySession } from '@/lib/session';
 import { redirect } from 'next/navigation';
+import SignOutButton from './components/SignOutButton';
 
 function money(n?: number | null) {
   if (n == null) return '—';
@@ -53,12 +54,7 @@ export default async function Home() {
     <main className="space-y-4">
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-semibold">VendorHub</h1>
-        <Link
-          href="/api/signout"
-          className="rounded-xl border border-gray-300 px-3 py-2 text-sm hover:bg-gray-100"
-        >
-          Sign out
-        </Link>
+        <SignOutButton />
       </div>
 
       {/* Simple table (same look you had) */}


### PR DESCRIPTION
## Summary
- Replace legacy sign-out link with client-side logout button
- Add SignOutButton component that posts to `/api/auth/logout` then redirects to `/signin`

## Testing
- `npm test` *(fails: Missing script "test")*
- `AUTH_SECRET=devsecret DATABASE_URL=postgresql://user:pass@localhost:5432/db npm run build` *(fails: Module '@lib/session' has no exported member 'verifySession')*
- `curl -i -X POST http://localhost:3000/api/auth/logout`

------
https://chatgpt.com/codex/tasks/task_e_689f51017d6c832a86b27acd0f50c365