### PR TITLE
Preserve zero-valued cost tier in vendor API

### DIFF
--- a/scripts/minTierCostCheck.ts
+++ b/scripts/minTierCostCheck.ts
@@ -1,0 +1,24 @@
+// scripts/minTierCostCheck.ts
+const assert = require("node:assert");
+
+function calcMinTierCost(costTiers: {
+  hourlyUsdMin: number | null;
+  hourlyUsdMax: number | null;
+}[]): number | null {
+  return (
+    costTiers
+      .map((t) => t.hourlyUsdMin ?? t.hourlyUsdMax ?? 0)
+      .filter((n) => n != null)
+      .sort((a, b) => a - b)[0] ?? null
+  );
+}
+
+const min = calcMinTierCost([
+  { hourlyUsdMin: 0, hourlyUsdMax: null },
+  { hourlyUsdMin: 5, hourlyUsdMax: 10 },
+]);
+
+assert.strictEqual(min, 0);
+
+console.log("minTierCost preserved:", min);
+

--- a/src/app/api/vendors/route.ts
+++ b/src/app/api/vendors/route.ts
@@ -45,8 +45,8 @@ export async function GET(req: NextRequest) {
       const minTierCost =
         v.costTiers
           .map((t) => t.hourlyUsdMin ?? t.hourlyUsdMax ?? 0)
-          .filter(Boolean)
-          .sort((a, b) => a - b)[0] || null;
+          .filter((n) => n != null)
+          .sort((a, b) => a - b)[0] ?? null;
 
       const ratings: number[] = [];
       for (const f of v.feedback) {


### PR DESCRIPTION
## Summary
- ensure vendor minTierCost keeps cost tiers with value 0
- add manual check script demonstrating zero cost tier is preserved

## Testing
- `npx ts-node scripts/minTierCostCheck.ts`


------
https://chatgpt.com/codex/tasks/task_e_689f511073d4832a9ef3621520cbbbe9