### PR TITLE
refactor SignIn page to use suspense

### DIFF
--- a/src/app/(auth)/signin/page.tsx
+++ b/src/app/(auth)/signin/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 
 declare global {
@@ -9,7 +9,15 @@ declare global {
   }
 }
 
-export default function SignIn() {
+export default function SignInPage() {
+  return (
+    <Suspense fallback={null}>
+      <SignIn />
+    </Suspense>
+  );
+}
+
+function SignIn() {
   const router = useRouter();
   const search = useSearchParams();
   const btnRef = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
## Summary
- split SignIn logic into an inner `SignIn` component
- add Suspense wrapper with null fallback around the sign-in UI

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689f53feea30832a861afd29d2718f20