### PR TITLE
feat: enhance session middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,9 +1,10 @@
-// middleware.ts
 import { NextRequest, NextResponse } from "next/server";
-import { verifyToken } from "@/lib/session";
+import { jwtVerify } from "jose";
+import { signSession, sessionCookie } from "@/lib/session";
 
-const PUBLIC_PREFIXES = [
+const PUBLIC_PATHS = [
   "/signin",
+  "/invite",
   "/api/auth/login",
   "/api/auth/logout",
   "/api/health",
@@ -13,15 +14,29 @@ const PUBLIC_PREFIXES = [
   "/sitemap.xml",
 ];
 
+const ISSUER = "vendorhub";
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+async function getSession(token?: string) {
+  if (!token) return null;
+  try {
+    const secret = new TextEncoder().encode(process.env.AUTH_SECRET || "");
+    const { payload } = await jwtVerify(token, secret, { issuer: ISSUER });
+    return payload as any;
+  } catch {
+    return null;
+  }
+}
+
 export async function middleware(req: NextRequest) {
   const { pathname, search } = req.nextUrl;
 
-  if (PUBLIC_PREFIXES.some((p) => pathname.startsWith(p))) {
+  if (pathname.startsWith("/api/webauthn") || PUBLIC_PATHS.some((p) => pathname.startsWith(p))) {
     return NextResponse.next();
   }
 
   const token = req.cookies.get("vh_session")?.value;
-  const session = await verifyToken(token);
+  const session = await getSession(token);
 
   if (process.env.AUTH_DEBUG === "1") {
     console.log("[mw]", pathname, "user:", session?.email || null);
@@ -34,9 +49,27 @@ export async function middleware(req: NextRequest) {
     return NextResponse.redirect(url);
   }
 
-  return NextResponse.next();
+  if (session.preAuth && pathname !== "/setup-passkey") {
+    const url = req.nextUrl.clone();
+    url.pathname = "/setup-passkey";
+    return NextResponse.redirect(url);
+  }
+
+  const { exp, iat, nbf, ...data } = session as any;
+  const res = NextResponse.next();
+
+  if (typeof exp === "number" && exp * 1000 - Date.now() < 7 * DAY_MS) {
+    const newToken = await signSession(data as any);
+    res.cookies.set(sessionCookie.name, newToken, {
+      ...sessionCookie.options,
+      maxAge: 30 * 24 * 60 * 60,
+    });
+  }
+
+  return res;
 }
 
 export const config = {
   matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
 };
+


### PR DESCRIPTION
## Summary
- allow unauthenticated access to sign-in, invite, and webauthn endpoints
- validate `vh_session` with `jwtVerify` and redirect pre-auth sessions
- refresh session cookie when expiration is within seven days

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f6fe761e0832aab02ebdfffde743c