### PR TITLE
feat: add invite token flow

### DIFF
--- a/src/app/api/admin/invites/route.ts
+++ b/src/app/api/admin/invites/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifySession } from "@/lib/session";
+import { signInvite } from "@/lib/invite";
+
+export async function POST(req: NextRequest) {
+  const session = await verifySession();
+  if (!session?.isAdmin) {
+    return NextResponse.json({ error: "admin only" }, { status: 403 });
+  }
+
+  const body = await req.json();
+  const email = body?.email as string | undefined;
+  if (!email) {
+    return NextResponse.json({ error: "email required" }, { status: 400 });
+  }
+
+  const token = await signInvite({ email });
+  const url = new URL(`/invite`, req.nextUrl.origin);
+  url.searchParams.set("token", token);
+
+  return NextResponse.json({ url: url.toString() });
+}

--- a/src/app/invite/route.ts
+++ b/src/app/invite/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifyInvite } from "@/lib/invite";
+import { prisma } from "@/lib/db";
+import { signSession, sessionCookie } from "@/lib/session";
+
+export async function GET(req: NextRequest) {
+  const token = req.nextUrl.searchParams.get("token") || "";
+  const invite = await verifyInvite(token);
+  if (!invite?.email) {
+    return NextResponse.redirect(new URL("/signin", req.url));
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { email: invite.email },
+  });
+  if (!user?.email) {
+    return NextResponse.redirect(new URL("/signin", req.url));
+  }
+
+  const session = await signSession(
+    {
+      sub: user.id,
+      email: user.email,
+      name: user.name ?? undefined,
+      isAdmin: user.isAdmin || undefined,
+      preAuth: true,
+    } as any,
+    60 * 10
+  );
+
+  const res = NextResponse.redirect(new URL("/setup-passkey", req.url));
+  res.cookies.set(sessionCookie.name, session, {
+    ...sessionCookie.options,
+    maxAge: 10 * 60,
+  });
+  return res;
+}

--- a/src/lib/invite.ts
+++ b/src/lib/invite.ts
@@ -1,0 +1,36 @@
+import { SignJWT, jwtVerify } from "jose";
+
+const ISSUER = "vendorhub-invite";
+
+function secretKey() {
+  const secret = process.env.AUTH_SECRET || "";
+  if (!secret) throw new Error("Missing AUTH_SECRET");
+  return new TextEncoder().encode(secret);
+}
+
+export type Invite = {
+  email: string;
+};
+
+export async function signInvite(
+  payload: Invite,
+  maxAgeSec = 60 * 60 * 24 // 1 day
+) {
+  const expires = Math.floor(Date.now() / 1000) + maxAgeSec;
+  return await new SignJWT(payload as any)
+    .setProtectedHeader({ alg: "HS256", typ: "JWT" })
+    .setIssuer(ISSUER)
+    .setIssuedAt()
+    .setExpirationTime(expires)
+    .sign(secretKey());
+}
+
+export async function verifyInvite(token?: string): Promise<Invite | null> {
+  try {
+    if (!token) return null;
+    const { payload } = await jwtVerify(token, secretKey(), { issuer: ISSUER });
+    return payload as unknown as Invite;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -17,6 +17,7 @@ export type Session = {
   email: string;
   name?: string;
   isAdmin?: boolean;
+  preAuth?: boolean;
 };
 
 export async function signSession(


### PR DESCRIPTION
## Summary
- add invite token utilities
- allow admins to mint invite links
- verify invite token and issue preAuth session

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f7232cccc832a95ddb8bb81ab39bc