### PR TITLE
feat: add passkey registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.next/
+next-env.d.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@prisma/client": "^5.16.1",
         "@simplewebauthn/browser": "^13.1.2",
+        "@simplewebauthn/server": "^13.1.2",
         "clsx": "^2.1.1",
         "google-auth-library": "^9.14.1",
         "jose": "^5.9.3",
@@ -71,6 +72,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@hexagon/base64": {
+      "version": "1.1.28",
+      "resolved": "https://registry.npmjs.org/@hexagon/base64/-/base64-1.1.28.tgz",
+      "integrity": "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==",
+      "license": "MIT"
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -127,6 +134,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@levischuck/tiny-cbor": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@levischuck/tiny-cbor/-/tiny-cbor-0.2.11.tgz",
+      "integrity": "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==",
+      "license": "MIT"
     },
     "node_modules/@next/env": {
       "version": "14.2.5",
@@ -316,6 +329,64 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@peculiar/asn1-android": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-android/-/asn1-android-2.4.0.tgz",
+      "integrity": "sha512-YFueREq97CLslZZBI8dKzis7jMfEHSLxM+nr0Zdx1POiXFLjqqwoY5s0F1UimdBiEw/iKlHey2m56MRDv7Jtyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.4.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.4.0.tgz",
+      "integrity": "sha512-fJiYUBCJBDkjh347zZe5H81BdJ0+OGIg0X9z06v8xXUoql3MFeENUX0JsjCaVaU9A0L85PefLPGYkIoGpTnXLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.4.0",
+        "@peculiar/asn1-x509": "^2.4.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.4.0.tgz",
+      "integrity": "sha512-6PP75voaEnOSlWR9sD25iCQyLgFZHXbmxvUfnnDcfL6Zh5h2iHW38+bve4LfH7a60x7fkhZZNmiYqAlAff9Img==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.4.0",
+        "@peculiar/asn1-x509": "^2.4.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.4.0.tgz",
+      "integrity": "sha512-umbembjIWOrPSOzEGG5vxFLkeM8kzIhLkgigtsOrfLKnuzxWxejAcUX+q/SoZCdemlODOcr5WiYa7+dIEzBXZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asn1js": "^3.0.6",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.4.0.tgz",
+      "integrity": "sha512-F7mIZY2Eao2TaoVqigGMLv+NDdpwuBKU1fucHPONfzaBS4JXXCNCmfO0Z3dsy7JzKGqtDcYC1mr9JjaZQZNiuw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.4.0",
+        "asn1js": "^3.0.6",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -400,6 +471,24 @@
       "resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-13.1.2.tgz",
       "integrity": "sha512-aZnW0KawAM83fSBUgglP5WofbrLbLyr7CoPqYr66Eppm7zO86YX6rrCjRB3hQKPrL7ATvY4FVXlykZ6w6FwYYw==",
       "license": "MIT"
+    },
+    "node_modules/@simplewebauthn/server": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/server/-/server-13.1.2.tgz",
+      "integrity": "sha512-VwoDfvLXSCaRiD+xCIuyslU0HLxVggeE5BL06+GbsP2l1fGf5op8e0c3ZtKoi+vSg1q4ikjtAghC23ze2Q3H9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@hexagon/base64": "^1.1.27",
+        "@levischuck/tiny-cbor": "^0.2.2",
+        "@peculiar/asn1-android": "^2.3.10",
+        "@peculiar/asn1-ecc": "^2.3.8",
+        "@peculiar/asn1-rsa": "^2.3.8",
+        "@peculiar/asn1-schema": "^2.3.8",
+        "@peculiar/asn1-x509": "^2.3.8"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
@@ -579,6 +668,20 @@
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/asn1js": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.6.tgz",
+      "integrity": "sha512-UOCGPYbl0tv8+006qks/dTgV9ajs97X2p0FAbyS2iyCRrmLSRolDaHdp+v/CLgnzHc3fVB+CwYiUmei7ndFcgA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/autoprefixer": {
       "version": "10.4.19",
@@ -1923,6 +2026,24 @@
       },
       "optionalDependencies": {
         "fsevents": "2.3.3"
+      }
+    },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
+      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/queue-microtask": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@prisma/client": "^5.16.1",
     "@simplewebauthn/browser": "^13.1.2",
+    "@simplewebauthn/server": "^13.1.2",
     "clsx": "^2.1.1",
     "google-auth-library": "^9.14.1",
     "jose": "^5.9.3",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -149,3 +149,15 @@ model VerificationToken {
 
   @@unique([identifier, token])
 }
+
+model Passkey {
+  id           String   @id @default(cuid())
+  email        String
+  credentialId String   @unique
+  publicKey    String
+  counter      Int
+  transports   String[] @db.Text
+
+  @@index([email])
+}
+

--- a/src/app/api/webauthn/register/options/route.ts
+++ b/src/app/api/webauthn/register/options/route.ts
@@ -1,0 +1,20 @@
+export const runtime = "nodejs";
+
+import { NextRequest, NextResponse } from "next/server";
+import { startRegistration } from "@/lib/webauthn";
+
+export async function POST(req: NextRequest) {
+  try {
+    const { email } = await req.json();
+    if (!email) {
+      return NextResponse.json({ error: "Missing email" }, { status: 400 });
+    }
+    const opts = await startRegistration(String(email));
+    return NextResponse.json(opts);
+  } catch (e: any) {
+    return NextResponse.json(
+      { error: e?.message || "Failed to start registration" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/webauthn/register/verify/route.ts
+++ b/src/app/api/webauthn/register/verify/route.ts
@@ -1,0 +1,29 @@
+export const runtime = "nodejs";
+
+import { NextRequest, NextResponse } from "next/server";
+import { finishRegistration } from "@/lib/webauthn";
+import { sessionCookie } from "@/lib/session";
+
+export async function POST(req: NextRequest) {
+  try {
+    const { email, credential } = await req.json();
+    if (!email || !credential) {
+      return NextResponse.json(
+        { error: "Missing parameters" },
+        { status: 400 }
+      );
+    }
+    const token = await finishRegistration(String(email), credential);
+    const res = NextResponse.json({ ok: true });
+    res.cookies.set(sessionCookie.name, token, {
+      ...sessionCookie.options,
+      maxAge: 60 * 60 * 24 * 30,
+    });
+    return res;
+  } catch (e: any) {
+    return NextResponse.json(
+      { error: e?.message || "Failed to verify registration" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/setup-passkey/page.tsx
+++ b/src/app/setup-passkey/page.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { startRegistration } from "@simplewebauthn/browser";
+
+export default function SetupPasskeyPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch("/api/auth/session")
+      .then((res) => res.json())
+      .then((j) => setEmail(j.user?.email || null))
+      .catch(() => setEmail(null));
+  }, []);
+
+  async function register() {
+    if (!email) return;
+    setLoading(true);
+    setErr(null);
+    try {
+      const optRes = await fetch("/api/webauthn/register/options", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+      if (!optRes.ok) {
+        const j = await optRes.json().catch(() => ({}));
+        throw new Error(j.error || "Failed to get options");
+      }
+      const opts = await optRes.json();
+      const attRes = await startRegistration({ optionsJSON: opts });
+      const verRes = await fetch("/api/webauthn/register/verify", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email, credential: attRes }),
+      });
+      if (!verRes.ok) {
+        const j = await verRes.json().catch(() => ({}));
+        throw new Error(j.error || "Failed to verify registration");
+      }
+      router.replace("/");
+    } catch (e: any) {
+      setErr(e.message || "Registration failed");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (email === null) {
+    return <main className="p-6">Loading...</main>;
+  }
+
+  return (
+    <main className="mx-auto max-w-md rounded-2xl border border-gray-200 bg-white p-6 text-center">
+      <h1 className="text-xl font-semibold">Set up your passkey</h1>
+      <p className="mt-1 text-sm text-gray-600">Create a passkey for {email}</p>
+      <button
+        onClick={register}
+        disabled={loading}
+        className="mt-4 w-full rounded bg-blue-600 px-4 py-2 font-medium text-white disabled:opacity-50"
+      >
+        {loading ? "Creating..." : "Create passkey"}
+      </button>
+      {err ? <p className="mt-3 text-sm text-red-600">{err}</p> : null}
+    </main>
+  );
+}

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -17,6 +17,8 @@ export type Session = {
   email: string;
   name?: string;
   isAdmin?: boolean;
+  preAuth?: boolean;
+  stage?: "pre" | "full";
 };
 
 export async function signSession(

--- a/src/lib/webauthn.ts
+++ b/src/lib/webauthn.ts
@@ -1,8 +1,11 @@
 import { randomBytes } from "crypto";
+import { generateRegistrationOptions, verifyRegistrationResponse } from "@simplewebauthn/server";
+import { prisma } from "@/lib/db";
 import { signSession } from "@/lib/session";
 
 // Simple in-memory challenge store keyed by email
 const challenges = new Map<string, string>();
+const regChallenges = new Map<string, string>();
 
 export async function startAuth(email: string) {
   const challenge = randomBytes(32).toString("base64url");
@@ -17,5 +20,51 @@ export async function finishAuth(email: string, assertion: any) {
   }
   challenges.delete(email);
   const token = await signSession({ sub: email, email });
+  return token;
+}
+
+export async function startRegistration(email: string) {
+  const existing = await prisma.passkey.findMany({ where: { email } });
+  const options = await generateRegistrationOptions({
+    rpName: "VendorHub",
+    rpID: process.env.WEBAUTHN_RP_ID || "localhost",
+    userID: Buffer.from(email),
+    userName: email,
+    attestationType: "none",
+    excludeCredentials: existing.map((c) => ({
+      id: c.credentialId,
+      type: "public-key",
+    })),
+  });
+  regChallenges.set(email, options.challenge);
+  return options;
+}
+
+export async function finishRegistration(email: string, attestation: any) {
+  const expected = regChallenges.get(email);
+  if (!expected) {
+    throw new Error("No challenge found");
+  }
+  const verification = await verifyRegistrationResponse({
+    response: attestation,
+    expectedChallenge: expected,
+    expectedOrigin: process.env.WEBAUTHN_ORIGIN || "http://localhost:3000",
+    expectedRPID: process.env.WEBAUTHN_RP_ID || "localhost",
+  });
+  if (!verification.verified || !verification.registrationInfo) {
+    throw new Error("Registration verification failed");
+  }
+  const { credential } = verification.registrationInfo;
+  await prisma.passkey.create({
+    data: {
+      email,
+      credentialId: credential.id,
+      publicKey: Buffer.from(credential.publicKey).toString("base64url"),
+      counter: credential.counter,
+      transports: credential.transports || [],
+    },
+  });
+  regChallenges.delete(email);
+  const token = await signSession({ sub: email, email, stage: "full" });
   return token;
 }


### PR DESCRIPTION
## Summary
- add WebAuthn registration helpers backed by Prisma
- expose WebAuthn registration option and verification API routes
- add passkey setup page and upgrade session to stage `full`

## Testing
- `AUTH_SECRET=secret DATABASE_URL=file:./dev.db npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f72359180832a80230d576e95c2ae