### PR TITLE
Use clearSession for logout endpoint

### DIFF
--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,9 +1,8 @@
 // src/app/api/auth/logout/route.ts
 import { NextResponse } from "next/server";
-import { sessionCookie } from "@/lib/session";
+import { clearSession } from "@/lib/session";
 
 export async function POST() {
-  const res = NextResponse.json({ ok: true });
-  res.cookies.set(sessionCookie.name, "", { ...sessionCookie.options, maxAge: 0 });
-  return res;
+  clearSession();
+  return NextResponse.json({ ok: true });
 }

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -63,3 +63,7 @@ export const sessionCookie = {
     path: "/",
   },
 };
+
+export function clearSession() {
+  cookies().set(sessionCookie.name, "", { ...sessionCookie.options, maxAge: 0 });
+}


### PR DESCRIPTION
## Summary
- add clearSession helper to centralize session cookie removal
- call clearSession from logout route and return `{ ok: true }`

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689f72368778832a9667fc30d2fcd08f