### PR TITLE
chore: update env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,13 @@
 DATABASE_URL="postgres://USER:PASSWORD@HOST:PORT/DBNAME"
 # Secret used to sign authentication tokens
 AUTH_SECRET="your-auth-secret"
-# Client ID from Google Identity Services
-NEXT_PUBLIC_GOOGLE_CLIENT_ID="your-google-client-id"
+# Secret used by the application (e.g., for invite tokens)
+APP_SECRET="your-app-secret"
+# WebAuthn relying party name
+RP_NAME="VendorHub"
+# WebAuthn relying party ID
+RP_ID="vendorhub.local"
+# Base URL for the application (used in invitation links)
+APP_URL="http://localhost:3000"
 # Comma-separated list of admin emails
 ADMIN_EMAILS="admin1@example.com,admin2@example.com"

--- a/README.md
+++ b/README.md
@@ -3,25 +3,18 @@
 ## Local Dev (optional)
 ```bash
 npm i
-cp .env.example .env # set DATABASE_URL, AUTH_SECRET, NEXT_PUBLIC_GOOGLE_CLIENT_ID, ADMIN_EMAILS
+cp .env.example .env # set DATABASE_URL, AUTH_SECRET, APP_SECRET, RP_NAME, RP_ID, APP_URL, ADMIN_EMAILS
 npx prisma migrate dev
 npm run dev
 ```
-
-## Authentication
-
-This project uses [Google Identity Services](https://developers.google.com/identity) for authentication.
-
-1. Create a Google Cloud project and enable Google Identity Services.
-2. Configure an OAuth 2.0 Client ID for a web application.
-3. Add `http://localhost:3000` to the authorized JavaScript origins for local development.
-4. Set the client ID as `NEXT_PUBLIC_GOOGLE_CLIENT_ID` (or `GOOGLE_CLIENT_ID`) in your environment.
-
 ## Environment
 
 - `DATABASE_URL` – connection string for Postgres
 - `AUTH_SECRET` – secret used to sign authentication tokens
-- `GOOGLE_CLIENT_ID` or `NEXT_PUBLIC_GOOGLE_CLIENT_ID` – client ID from Google Identity Services
+- `APP_SECRET` – secret used by the application (e.g., for invite tokens)
+- `RP_NAME` – WebAuthn relying party name
+- `RP_ID` – WebAuthn relying party ID
+- `APP_URL` – base URL of the application (used in invitation links)
 - `ADMIN_EMAILS` – comma‑separated emails with admin access. During sign‑in, if the user's email (case‑insensitive) matches one of these, the JWT will include `isAdmin: true`.
 
 ## Deploy (Vercel + Neon, recommended)

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -13,7 +13,7 @@ function secretKey() {
 }
 
 export type Session = {
-  sub: string;       // Google user id
+  sub: string;       // user id
   email: string;
   name?: string;
   isAdmin?: boolean;


### PR DESCRIPTION
## Summary
- remove Google client ID env var
- add APP_SECRET, RP_NAME, RP_ID, and APP_URL examples
- drop Google-specific auth docs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f7238a490832a8f860866b45c6480