### PR TITLE
Refactor auth to use session middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { jwtVerify } from "jose";
-import { signSession, sessionCookie } from "@/lib/session";
+import { getSession, signSession, sessionCookie } from "@/lib/session";
 
 const PUBLIC_PATHS = [
   "/signin",
@@ -14,19 +13,7 @@ const PUBLIC_PATHS = [
   "/sitemap.xml",
 ];
 
-const ISSUER = "vendorhub";
 const DAY_MS = 24 * 60 * 60 * 1000;
-
-async function getSession(token?: string) {
-  if (!token) return null;
-  try {
-    const secret = new TextEncoder().encode(process.env.AUTH_SECRET || "");
-    const { payload } = await jwtVerify(token, secret, { issuer: ISSUER });
-    return payload as any;
-  } catch {
-    return null;
-  }
-}
 
 export async function middleware(req: NextRequest) {
   const { pathname, search } = req.nextUrl;
@@ -35,8 +22,7 @@ export async function middleware(req: NextRequest) {
     return NextResponse.next();
   }
 
-  const token = req.cookies.get("vh_session")?.value;
-  const session = await getSession(token);
+  const session = await getSession(req);
 
   if (process.env.AUTH_DEBUG === "1") {
     console.log("[mw]", pathname, "user:", session?.email || null);

--- a/src/app/api/auth/session/route.ts
+++ b/src/app/api/auth/session/route.ts
@@ -1,8 +1,8 @@
 // src/app/api/auth/session/route.ts
 import { NextRequest, NextResponse } from "next/server";
-import { verifySession } from "@/lib/session";
+import { getSession } from "@/lib/session";
 
 export async function GET(_req: NextRequest) {
-  const s = await verifySession();
+  const s = await getSession();
   return NextResponse.json({ user: s });
 }

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -5,7 +5,7 @@ export const runtime = 'nodejs';
 
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
-import { verifySession } from '@/lib/session';
+import { getSession } from '@/lib/session';
 
 export async function POST(req: NextRequest) {
   try {
@@ -14,8 +14,11 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'vendorId required' }, { status: 400 });
     }
 
-    const session = await verifySession();
-    const author = session?.email || b.author || 'anon';
+    const session = await getSession();
+    if (!session?.email) {
+      return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+    }
+    const author = session.email;
 
     const fb = await prisma.feedback.create({
       data: {

--- a/src/app/api/vendors/[id]/route.ts
+++ b/src/app/api/vendors/[id]/route.ts
@@ -5,16 +5,15 @@ export const runtime = 'nodejs';
 
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
-// ✅ no "@/lib/auth" anymore
-import { verifySession } from '@/lib/session';
+import { getSession } from '@/lib/session';
 
 export async function GET(
   _req: NextRequest,
   { params }: { params: { id: string } }
 ) {
   try {
-    // Optional: require login for this API; comment out if you want it public
-    const session = await verifySession();
+    // Require login for this API
+    const session = await getSession();
     if (!session?.email) {
       return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
     }

--- a/src/app/api/vendors/route.ts
+++ b/src/app/api/vendors/route.ts
@@ -5,9 +5,13 @@ export const runtime = "nodejs";
 
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
-import { verifySession } from "@/lib/session";
+import { getSession } from "@/lib/session";
 
 export async function GET(req: NextRequest) {
+  const session = await getSession();
+  if (!session?.email) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
   const { searchParams } = new URL(req.url);
   const q = searchParams.get("query") ?? "";
   const cap = searchParams.get("cap") ?? "";
@@ -96,7 +100,7 @@ export async function GET(req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
-  const session = await verifySession();
+  const session = await getSession();
   if (!session?.isAdmin) {
     return NextResponse.json({ error: "admin only" }, { status: 403 });
   }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,8 +3,6 @@ import { prisma } from '@/lib/db';
 import { computeAvgRating } from '@/lib/scoring';
 import Link from 'next/link';
 import React from 'react';
-import { verifySession } from '@/lib/session';
-import { redirect } from 'next/navigation';
 import SignOutButton from './components/SignOutButton';
 
 function money(n?: number | null) {
@@ -13,12 +11,6 @@ function money(n?: number | null) {
 }
 
 export default async function Home() {
-  // 👇 Require login before rendering the table
-  const session = await verifySession();
-  if (!session?.email) {
-    redirect(`/signin?callbackUrl=/`);
-  }
-
   // fetch vendors (exactly like you had before)
   const vendors = await prisma.vendor.findMany({
     include: {

--- a/src/app/vendor/[id]/page.tsx
+++ b/src/app/vendor/[id]/page.tsx
@@ -3,8 +3,6 @@ import { prisma } from '@/lib/db';
 import { computeAvgRating } from '@/lib/scoring';
 import Link from 'next/link';
 import React from 'react';
-import { verifySession } from '@/lib/session';
-import { redirect } from 'next/navigation';
 import AddFeedback from './AddFeedback.client';
 
 function fmtSvc(arr?: string[] | null) {
@@ -24,12 +22,6 @@ function money(n?: number | null) {
 }
 
 export default async function VendorPage({ params }: { params: { id: string } }) {
-  // 👇 Require login before showing vendor details
-  const session = await verifySession(); // ✅ fix: "const", not "onst"
-  if (!session?.email) {
-    redirect(`/signin?callbackUrl=/vendor/${params.id}`);
-  }
-
   const v = await prisma.vendor.findUnique({
     where: { id: params.id },
     include: {

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -17,6 +17,7 @@ export type Session = {
   email: string;
   name?: string;
   isAdmin?: boolean;
+  preAuth?: boolean;
 };
 
 export async function signSession(
@@ -42,15 +43,10 @@ export async function verifyToken(token?: string): Promise<Session | null> {
   }
 }
 
-export async function verifySession(): Promise<Session | null> {
-  const token = cookies().get(COOKIE_NAME)?.value;
-  return verifyToken(token);
-}
-
-export async function getSessionFromRequest(
-  req: NextRequest
-): Promise<Session | null> {
-  const token = req.cookies.get(COOKIE_NAME)?.value;
+export async function getSession(req?: NextRequest): Promise<Session | null> {
+  const token = req
+    ? req.cookies.get(COOKIE_NAME)?.value
+    : cookies().get(COOKIE_NAME)?.value;
   return verifyToken(token);
 }
 


### PR DESCRIPTION
## Summary
- centralize session retrieval with new `getSession`
- enforce session-based authorization across API routes
- drop manual session checks from pages to rely on middleware

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_689f7239a420832a9ac6e5e5f624027d