### PR TITLE
feat: integrate simplewebauthn auth

### DIFF
--- a/src/lib/webauthn.ts
+++ b/src/lib/webauthn.ts
@@ -1,5 +1,10 @@
-import { randomBytes } from "crypto";
-import { generateRegistrationOptions, verifyRegistrationResponse } from "@simplewebauthn/server";
+import {
+  generateAuthenticationOptions,
+  verifyAuthenticationResponse,
+  generateRegistrationOptions,
+  verifyRegistrationResponse,
+  type AuthenticatorTransportFuture,
+} from "@simplewebauthn/server";
 import { prisma } from "@/lib/db";
 import { signSession } from "@/lib/session";
 
@@ -8,18 +13,66 @@ const challenges = new Map<string, string>();
 const regChallenges = new Map<string, string>();
 
 export async function startAuth(email: string) {
-  const challenge = randomBytes(32).toString("base64url");
-  challenges.set(email, challenge);
-  return { challenge };
+  const passkeys = await prisma.passkey.findMany({ where: { email } });
+  const options = await generateAuthenticationOptions({
+    rpID: process.env.WEBAUTHN_RP_ID || "localhost",
+    allowCredentials: passkeys.map((p) => ({
+      id: p.credentialId,
+      transports: p.transports as AuthenticatorTransportFuture[],
+    })),
+  });
+  challenges.set(email, options.challenge);
+  return options;
 }
 
 export async function finishAuth(email: string, assertion: any) {
   const expected = challenges.get(email);
-  if (!expected || assertion?.challenge !== expected) {
-    throw new Error("Invalid assertion");
+  if (!expected) {
+    throw new Error("No challenge found");
   }
+
+  const passkey = await prisma.passkey.findUnique({
+    where: { credentialId: assertion.id },
+  });
+  if (!passkey || passkey.email !== email) {
+    throw new Error("Passkey not found for user");
+  }
+
+  const verification = await verifyAuthenticationResponse({
+    response: assertion,
+    expectedChallenge: expected,
+    expectedOrigin: process.env.WEBAUTHN_ORIGIN || "http://localhost:3000",
+    expectedRPID: process.env.WEBAUTHN_RP_ID || "localhost",
+    credential: {
+      id: passkey.credentialId,
+      publicKey: Buffer.from(passkey.publicKey, "base64url"),
+      counter: passkey.counter,
+      transports: passkey.transports as AuthenticatorTransportFuture[],
+    },
+  });
+
+  if (!verification.verified) {
+    throw new Error("Authentication verification failed");
+  }
+
+  await prisma.passkey.update({
+    where: { credentialId: passkey.credentialId },
+    data: { counter: verification.authenticationInfo.newCounter },
+  });
+
   challenges.delete(email);
-  const token = await signSession({ sub: email, email });
+
+  const user = await prisma.user.findUnique({ where: { email } });
+  if (!user) {
+    throw new Error("User not found");
+  }
+
+  const token = await signSession({
+    sub: user.id,
+    email: user.email || email,
+    name: user.name || undefined,
+    isAdmin: user.isAdmin,
+  });
   return token;
 }
 


### PR DESCRIPTION
## Summary
- switch to SimpleWebAuthn for authentication
- verify credential against stored passkey and update counter
- fill session with user info after successful assertion

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Module '@/lib/session' has no exported member 'verifySession')

------
https://chatgpt.com/codex/tasks/task_e_689f9bfb7550832a8fd4741fbd18b356