### PR TITLE
Persist WebAuthn challenges

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,6 +23,11 @@ enum ServiceOption {
   FTE
 }
 
+enum ChallengeType {
+  AUTH
+  REG
+}
+
 // ----- Core models -----
 
 model Vendor {
@@ -159,5 +164,16 @@ model Passkey {
   transports   String[] @db.Text
 
   @@index([email])
+}
+
+model WebAuthnChallenge {
+  id        String        @id @default(cuid())
+  email     String
+  type      ChallengeType
+  challenge String
+  expiresAt DateTime
+
+  @@unique([email, type])
+  @@index([expiresAt])
 }
 

--- a/src/lib/webauthn.ts
+++ b/src/lib/webauthn.ts
@@ -2,23 +2,33 @@ import { randomBytes } from "crypto";
 import { generateRegistrationOptions, verifyRegistrationResponse } from "@simplewebauthn/server";
 import { prisma } from "@/lib/db";
 import { signSession } from "@/lib/session";
+import { ChallengeType } from "@prisma/client";
 
-// Simple in-memory challenge store keyed by email
-const challenges = new Map<string, string>();
-const regChallenges = new Map<string, string>();
+const CHALLENGE_TTL_MS = 5 * 60 * 1000;
 
 export async function startAuth(email: string) {
   const challenge = randomBytes(32).toString("base64url");
-  challenges.set(email, challenge);
+  const expiresAt = new Date(Date.now() + CHALLENGE_TTL_MS);
+  await prisma.webAuthnChallenge.upsert({
+    where: { email_type: { email, type: ChallengeType.AUTH } },
+    update: { challenge, expiresAt },
+    create: { email, type: ChallengeType.AUTH, challenge, expiresAt },
+  });
+  await prisma.webAuthnChallenge.deleteMany({ where: { expiresAt: { lt: new Date() } } });
   return { challenge };
 }
 
 export async function finishAuth(email: string, assertion: any) {
-  const expected = challenges.get(email);
-  if (!expected || assertion?.challenge !== expected) {
+  const record = await prisma.webAuthnChallenge.findUnique({
+    where: { email_type: { email, type: ChallengeType.AUTH } },
+  });
+  if (!record || record.challenge !== assertion?.challenge || record.expiresAt < new Date()) {
+    if (record) {
+      await prisma.webAuthnChallenge.delete({ where: { email_type: { email, type: ChallengeType.AUTH } } });
+    }
     throw new Error("Invalid assertion");
   }
-  challenges.delete(email);
+  await prisma.webAuthnChallenge.delete({ where: { email_type: { email, type: ChallengeType.AUTH } } });
   const token = await signSession({ sub: email, email });
   return token;
 }
@@ -36,22 +46,34 @@ export async function startRegistration(email: string) {
       type: "public-key",
     })),
   });
-  regChallenges.set(email, options.challenge);
+  const expiresAt = new Date(Date.now() + CHALLENGE_TTL_MS);
+  await prisma.webAuthnChallenge.upsert({
+    where: { email_type: { email, type: ChallengeType.REG } },
+    update: { challenge: options.challenge, expiresAt },
+    create: { email, type: ChallengeType.REG, challenge: options.challenge, expiresAt },
+  });
+  await prisma.webAuthnChallenge.deleteMany({ where: { expiresAt: { lt: new Date() } } });
   return options;
 }
 
 export async function finishRegistration(email: string, attestation: any) {
-  const expected = regChallenges.get(email);
-  if (!expected) {
+  const record = await prisma.webAuthnChallenge.findUnique({
+    where: { email_type: { email, type: ChallengeType.REG } },
+  });
+  if (!record || record.expiresAt < new Date()) {
+    if (record) {
+      await prisma.webAuthnChallenge.delete({ where: { email_type: { email, type: ChallengeType.REG } } });
+    }
     throw new Error("No challenge found");
   }
   const verification = await verifyRegistrationResponse({
     response: attestation,
-    expectedChallenge: expected,
+    expectedChallenge: record.challenge,
     expectedOrigin: process.env.WEBAUTHN_ORIGIN || "http://localhost:3000",
     expectedRPID: process.env.WEBAUTHN_RP_ID || "localhost",
   });
   if (!verification.verified || !verification.registrationInfo) {
+    await prisma.webAuthnChallenge.delete({ where: { email_type: { email, type: ChallengeType.REG } } });
     throw new Error("Registration verification failed");
   }
   const { credential } = verification.registrationInfo;
@@ -64,7 +86,7 @@ export async function finishRegistration(email: string, attestation: any) {
       transports: credential.transports || [],
     },
   });
-  regChallenges.delete(email);
+  await prisma.webAuthnChallenge.delete({ where: { email_type: { email, type: ChallengeType.REG } } });
   const token = await signSession({ sub: email, email, stage: "full" });
   return token;
 }


### PR DESCRIPTION
## Summary
- store WebAuthn auth and registration challenges in Prisma model with TTL
- verify, delete and expire challenges instead of using in-memory maps

## Testing
- `npx prisma generate`
- `npx prisma migrate dev --name add-webauthn-challenges` *(fails: Environment variable not found: DATABASE_URL)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f9bfd1924832abe89b965ad4d9baf