### PR TITLE
chore: remove oauth models

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -96,8 +96,6 @@ model Feedback {
   createdAt     DateTime @default(now())
 }
 
-// ----- NextAuth models (standard) -----
-
 model User {
   id             String    @id @default(cuid())
   name           String?
@@ -107,47 +105,6 @@ model User {
 
   // Custom RBAC flag
   isAdmin        Boolean   @default(false)
-
-  accounts       Account[]
-  sessions       Session[]
-}
-
-model Account {
-  id                       String  @id @default(cuid())
-  userId                   String
-  type                     String
-  provider                 String
-  providerAccountId        String
-  refresh_token            String?
-  access_token             String?
-  expires_at               Int?
-  token_type               String?
-  scope                    String?
-  id_token                 String?
-  session_state            String?
-  oauth_token_secret       String?
-  oauth_token              String?
-
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
-
-  @@unique([provider, providerAccountId])
-}
-
-model Session {
-  id           String   @id @default(cuid())
-  sessionToken String   @unique
-  userId       String
-  expires      DateTime
-
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
-}
-
-model VerificationToken {
-  identifier String
-  token      String   @unique
-  expires    DateTime
-
-  @@unique([identifier, token])
 }
 
 model Passkey {


### PR DESCRIPTION
## Summary
- drop Account, Session, and VerificationToken models
- remove related fields from User schema

## Testing
- `npx prisma migrate dev --name remove-oauth-models` *(fails: Can't reach database server at `localhost:5432`)*
- `npx prisma generate`
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_689f9bfdfb54832aafd6e16bdcca6ba7