### PR TITLE
refactor: use getSession in admin invite route

### DIFF
--- a/src/app/api/admin/invites/route.ts
+++ b/src/app/api/admin/invites/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
-import { verifySession } from "@/lib/session";
+import { getSession } from "@/lib/session";
 import { signInvite } from "@/lib/invite";
 
 export async function POST(req: NextRequest) {
-  const session = await verifySession();
+  const session = await getSession();
   if (!session?.isAdmin) {
     return NextResponse.json({ error: "admin only" }, { status: 403 });
   }


### PR DESCRIPTION
## Summary
- replace `verifySession` with `getSession` in admin invites route

## Testing
- `npm run build` *(fails: Error: the name `finishAuth` is defined multiple times in src/lib/webauthn.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689fa9915c9c832ab6bc33167be173f4