### PR TITLE
Refactor WebAuthn authentication flow with in-memory challenges

### DIFF
--- a/src/lib/webauthn.test.ts
+++ b/src/lib/webauthn.test.ts
@@ -1,0 +1,14 @@
+import { startAuth, finishAuth } from "./webauthn";
+
+async function compileCheck() {
+  const options = await startAuth("user@example.com");
+  if (typeof options.challenge !== "string") {
+    throw new Error("challenge should be string");
+  }
+  try {
+    await finishAuth("user@example.com", {} as any);
+  } catch {
+    // Expected failure in test environment
+  }
+}
+compileCheck();


### PR DESCRIPTION
## Summary
- simplify WebAuthn authentication flow by generating options in `startAuth` and storing challenge in memory
- verify responses against stored challenge and issue session token in `finishAuth`
- add TypeScript test to ensure auth functions compile

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc --noEmit` *(fails: Module '@/lib/session' has no exported member 'verifySession')*

------
https://chatgpt.com/codex/tasks/task_e_689fa992f800832a9f1e0543e442cb41