### PR TITLE
Improve health API response formatting

### DIFF
--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,1 +1,7 @@
-export async function GET() { return new Response(JSON.stringify({ ok:true }), { headers: { 'content-type': 'application/json' } }); }
+export async function GET() {
+  return new Response(JSON.stringify({ ok: true }), {
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- format health GET route across multiple lines
- set JSON Content-Type and return `{ ok: true }`

## Testing
- `npx prettier --write src/app/api/health/route.ts`
- `npx eslint src/app/api/health/route.ts` *(fails: ESLint couldn't find an eslint.config file)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689fa9949eb0832aa3c10033c6704d84