### PR TITLE
Enforce auth middleware routes and test redirects

### DIFF
--- a/middleware.test.ts
+++ b/middleware.test.ts
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import { NextRequest } from 'next/server';
+import { middleware } from './middleware';
+import { signSession, sessionCookie } from './src/lib/session';
+
+process.env.AUTH_SECRET = 'test-secret';
+
+async function makeRequest(path: string, auth: boolean) {
+  const url = `http://localhost${path}`;
+  const headers: Record<string, string> = {};
+  if (auth) {
+    const token = await signSession({ sub: '1', email: 'a@example.com' });
+    headers['cookie'] = `${sessionCookie.name}=${token}`;
+  }
+  return new NextRequest(url, { headers });
+}
+
+(async () => {
+  // unauthenticated root should redirect to /signin
+  {
+    const res = await middleware(await makeRequest('/', false));
+    assert(res.headers.get('location'));
+    const loc = new URL(res.headers.get('location')!);
+    assert.equal(loc.pathname, '/signin');
+    assert.equal(loc.searchParams.get('callbackUrl'), '/');
+  }
+
+  // authenticated root should pass through
+  {
+    const res = await middleware(await makeRequest('/', true));
+    assert.equal(res.headers.get('location'), null);
+  }
+
+  // unauthenticated vendor page should redirect
+  {
+    const res = await middleware(await makeRequest('/vendor/123', false));
+    assert(res.headers.get('location'));
+    const loc = new URL(res.headers.get('location')!);
+    assert.equal(loc.pathname, '/signin');
+    assert.equal(loc.searchParams.get('callbackUrl'), '/vendor/123');
+  }
+
+  // authenticated vendor page should pass through
+  {
+    const res = await middleware(await makeRequest('/vendor/123', true));
+    assert.equal(res.headers.get('location'), null);
+  }
+
+  console.log('middleware tests passed');
+})();

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,11 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getSession, signSession, sessionCookie } from "@/lib/session";
+import { getSession, signSession, sessionCookie } from "./src/lib/session";
 
 const PUBLIC_PATHS = [
   "/signin",
   "/invite",
-  "/api/auth/login",
-  "/api/auth/logout",
+  "/api/auth",
   "/api/health",
   "/_next",
   "/favicon.ico",
@@ -56,6 +55,6 @@ export async function middleware(req: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+  matcher: ["/:path*"],
 };
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "postinstall": "prisma generate",
     "seed": "ts-node --transpile-only prisma/seed.ts",
-    "test": "ts-node --compiler-options '{\"module\":\"CommonJS\",\"moduleResolution\":\"node\"}' src/lib/vendorFilters.test.ts"
+    "test": "ts-node --compiler-options '{\"module\":\"CommonJS\",\"moduleResolution\":\"node\"}' src/lib/vendorFilters.test.ts && ts-node --compiler-options '{\"module\":\"CommonJS\",\"moduleResolution\":\"node\"}' middleware.test.ts"
   },
   "dependencies": {
     "@prisma/client": "^5.16.1",


### PR DESCRIPTION
## Summary
- Restrict middleware public paths to only auth, invite, health, and static assets
- Apply middleware to all routes
- Add tests for middleware redirect behavior for `/` and `/vendor/:id`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0d8278cdc832abf02da377543bfc7