### PR TITLE
Fix package.json JSON syntax and streamline test scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "start": "next start",
     "postinstall": "prisma generate",
     "seed": "ts-node --transpile-only prisma/seed.ts",
-    "test": "npm run test:lib && vitest run",
-    "test:lib": "ts-node --compiler-options '{\"module\":\"CommonJS\",\"moduleResolution\":\"node\"}' src/lib/vendorFilters.test.ts"
-    "test": "ts-node --compiler-options '{\"module\":\"CommonJS\",\"moduleResolution\":\"node\"}' src/lib/vendorFilters.test.ts && ts-node --compiler-options '{\"module\":\"CommonJS\",\"moduleResolution\":\"node\"}' middleware.test.ts"
+    "test": "npm run test:lib && npm run test:middleware && vitest run",
+    "test:lib": "ts-node --compiler-options '{\"module\":\"CommonJS\",\"moduleResolution\":\"node\"}' src/lib/vendorFilters.test.ts",
+    "test:middleware": "ts-node --compiler-options '{\"module\":\"CommonJS\",\"moduleResolution\":\"node\"}' middleware.test.ts"
   },
   "dependencies": {
     "@prisma/client": "^5.16.1",


### PR DESCRIPTION
## Summary
- fix missing comma in `package.json` scripts causing JSON parse failure
- consolidate test scripts and add middleware test to npm test workflow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0dbadfd70832a96fe2905c94d0d20