### PR TITLE
fix middleware matcher to include root

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -67,5 +67,5 @@ export async function middleware(req: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/:path*"],
+  matcher: ["/(.*)"],
 };


### PR DESCRIPTION
## Summary
- ensure middleware runs on root path by using `matcher: ['/(.*)']`

## Testing
- `npm test`
- `npx vercel --prod` *(fails: Project not set up)*
- `curl -I https://vendorhub-next.vercel.app/` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ece4effc832ab40a9dd2e5158ff0